### PR TITLE
Add anti-aim feature

### DIFF
--- a/cstrike/core/menu.cpp
+++ b/cstrike/core/menu.cpp
@@ -351,7 +351,21 @@ void T::Render(const char* szTabBar, const CTab* arrTabs, const unsigned long lo
 }
 
 void T::RageBot()
-{ }
+{
+        ImGui::BeginChild(CS_XOR("ragebot.anti_aim"), ImVec2{}, true, ImGuiWindowFlags_MenuBar);
+        {
+                if (ImGui::BeginMenuBar())
+                {
+                        ImGui::TextUnformatted(CS_XOR("anti-aim"));
+                        ImGui::EndMenuBar();
+                }
+
+                ImGui::Checkbox(CS_XOR("enable##antiaim"), &C_GET(bool, Vars.bAntiAim));
+                ImGui::Combo(CS_XOR("base yaw"), &C_GET(int, Vars.iBaseYawType), CS_XOR("none\0backwards\0forwards\0"));
+                ImGui::Combo(CS_XOR("pitch"), &C_GET(int, Vars.iPitchType), CS_XOR("none\0down\0up\0zero\0"));
+        }
+        ImGui::EndChild();
+}
 
 void T::LegitBot()
 {

--- a/cstrike/core/variables.h
+++ b/cstrike/core/variables.h
@@ -25,12 +25,31 @@ using MiscDpiScale_t = int;
 
 enum EMiscDpiScale : MiscDpiScale_t
 {
-	MISC_DPISCALE_DEFAULT = 0,
-	MISC_DPISCALE_125,
-	MISC_DPISCALE_150,
-	MISC_DPISCALE_175,
-	MISC_DPISCALE_200,
-	MISC_DPISCALE_MAX
+        MISC_DPISCALE_DEFAULT = 0,
+        MISC_DPISCALE_125,
+        MISC_DPISCALE_150,
+        MISC_DPISCALE_175,
+        MISC_DPISCALE_200,
+        MISC_DPISCALE_MAX
+};
+
+using AntiAimYaw_t = int;
+enum EAntiAimYaw : AntiAimYaw_t
+{
+        ANTIAIM_YAW_NONE = 0,
+        ANTIAIM_YAW_BACKWARDS,
+        ANTIAIM_YAW_FORWARDS,
+        ANTIAIM_YAW_MAX
+};
+
+using AntiAimPitch_t = int;
+enum EAntiAimPitch : AntiAimPitch_t
+{
+        ANTIAIM_PITCH_NONE = 0,
+        ANTIAIM_PITCH_DOWN,
+        ANTIAIM_PITCH_UP,
+        ANTIAIM_PITCH_ZERO,
+        ANTIAIM_PITCH_MAX
 };
 
 #pragma endregion
@@ -111,10 +130,16 @@ struct Variables_t
 
 	C_ADD_VARIABLE(ColorPickerVar_t, colAccent0, ColorPickerVar_t(85, 90, 160)); // (main)
 	C_ADD_VARIABLE(ColorPickerVar_t, colAccent1, ColorPickerVar_t(100, 105, 175)); // (dark)
-	C_ADD_VARIABLE(ColorPickerVar_t, colAccent2, ColorPickerVar_t(115, 120, 190)); // (darker)
+        C_ADD_VARIABLE(ColorPickerVar_t, colAccent2, ColorPickerVar_t(115, 120, 190)); // (darker)
+#pragma endregion
+
+#pragma region variables_antiaim
+        C_ADD_VARIABLE(bool, bAntiAim, false);
+        C_ADD_VARIABLE(int, iBaseYawType, ANTIAIM_YAW_NONE);
+        C_ADD_VARIABLE(int, iPitchType, ANTIAIM_PITCH_NONE);
 #pragma endregion
 #pragma region variables_legitbot
-	C_ADD_VARIABLE(bool, bLegitbot, false);
+        C_ADD_VARIABLE(bool, bLegitbot, false);
 	C_ADD_VARIABLE(float, flAimRange, 10.0f);
 	C_ADD_VARIABLE(float, flSmoothing, 10.0f);
 	C_ADD_VARIABLE(bool, bLegitbotAlwaysOn, false);

--- a/cstrike/cstrike.vcxproj
+++ b/cstrike/cstrike.vcxproj
@@ -159,6 +159,7 @@
     <ClInclude Include="features\CRC.h" />
     <ClInclude Include="features\legitbot\aim.h" />
     <ClInclude Include="features\legitbot\legitbot.h" />
+    <ClInclude Include="features\anti_aim\anti_aim.h" />
     <ClInclude Include="features\misc.h" />
     <ClInclude Include="features\misc\movement.h" />
     <ClInclude Include="features\visuals.h" />
@@ -232,6 +233,7 @@
     <ClCompile Include="..\dependencies\minhook\trampoline.c" />
     <ClCompile Include="features\legitbot.cpp" />
     <ClCompile Include="features\legitbot\aim.cpp" />
+    <ClCompile Include="features\anti_aim\anti_aim.cpp" />
     <ClCompile Include="sdk\interfaces\cgametracemanager.cpp" />
     <ClCompile Include="core.cpp" />
     <ClCompile Include="core\config.cpp" />

--- a/cstrike/cstrike.vcxproj.filters
+++ b/cstrike/cstrike.vcxproj.filters
@@ -43,6 +43,9 @@
     <Filter Include="features\legitbot">
       <UniqueIdentifier>{a0df371b-f244-4c53-b08d-762a0f9b6b0c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="features\anti_aim">
+      <UniqueIdentifier>{E1B6CC4F-E6E0-4F41-B4BB-0E3B8156DBAB}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\dependencies\imgui\imconfig.h">
@@ -320,11 +323,14 @@
     <ClInclude Include="features\legitbot\legitbot.h">
       <Filter>features</Filter>
     </ClInclude>
-    <ClInclude Include="features\legitbot\aim.h">
-      <Filter>features\legitbot</Filter>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
+  <ClInclude Include="features\legitbot\aim.h">
+    <Filter>features\legitbot</Filter>
+  </ClInclude>
+  <ClInclude Include="features\anti_aim\anti_aim.h">
+    <Filter>features\anti_aim</Filter>
+  </ClInclude>
+</ItemGroup>
+<ItemGroup>
     <ClCompile Include="..\dependencies\imgui\imgui.cpp">
       <Filter>dependencies\imgui</Filter>
     </ClCompile>
@@ -436,11 +442,14 @@
     <ClCompile Include="sdk\interfaces\cgametracemanager.cpp">
       <Filter>sdk\interfaces</Filter>
     </ClCompile>
-    <ClCompile Include="features\legitbot\aim.cpp">
-      <Filter>features\legitbot</Filter>
-    </ClCompile>
-    <ClCompile Include="features\legitbot.cpp">
-      <Filter>features</Filter>
-    </ClCompile>
-  </ItemGroup>
+  <ClCompile Include="features\legitbot\aim.cpp">
+    <Filter>features\legitbot</Filter>
+  </ClCompile>
+  <ClCompile Include="features\legitbot.cpp">
+    <Filter>features</Filter>
+  </ClCompile>
+  <ClCompile Include="features\anti_aim\anti_aim.cpp">
+    <Filter>features\anti_aim</Filter>
+  </ClCompile>
+</ItemGroup>
 </Project>

--- a/cstrike/features.cpp
+++ b/cstrike/features.cpp
@@ -14,6 +14,7 @@
 #include "features/visuals.h"
 #include "features/misc.h"
 #include "features/legitbot.h"
+#include "features/anti_aim/anti_aim.h"
 
 // used: interfaces
 #include "core/interfaces.h"
@@ -70,8 +71,9 @@ void F::OnCreateMove(CUserCmd* pCmd, CBaseUserCmdPB* pBaseCmd, CCSPlayerControll
 	if (pLocalPawn == nullptr)
 		return;
 
-	F::MISC::OnMove(pCmd, pBaseCmd, pLocalController, pLocalPawn);
-	F::LEGITBOT::OnMove(pCmd, pBaseCmd, pLocalController, pLocalPawn);
+        F::MISC::OnMove(pCmd, pBaseCmd, pLocalController, pLocalPawn);
+        F::LEGITBOT::OnMove(pCmd, pBaseCmd, pLocalController, pLocalPawn);
+        F::ANTIAIM::RunAA(pCmd, pBaseCmd, pLocalController, pLocalPawn);
 }
 
 bool F::OnDrawObject(void* pAnimatableSceneObjectDesc, void* pDx11, CMeshData* arrMeshDraw, int nDataCount, void* pSceneView, void* pSceneLayer, void* pUnk, void* pUnk2)

--- a/cstrike/features/anti_aim/anti_aim.cpp
+++ b/cstrike/features/anti_aim/anti_aim.cpp
@@ -1,0 +1,72 @@
+#include "anti_aim.h"
+
+// used: sdk entity
+#include "../../sdk/entity.h"
+#include "../../sdk/interfaces/cgameentitysystem.h"
+#include "../../sdk/interfaces/iengineclient.h"
+
+// used: cheat variables
+#include "../../core/variables.h"
+#include "../../core/interfaces.h"
+#include "../../core/sdk.h"
+
+// used: usercmd
+#include "../../sdk/datatypes/usercmd.h"
+
+#include <cmath>
+
+void F::ANTIAIM::RunAA(CUserCmd* pCmd, CBaseUserCmdPB* pBaseCmd, CCSPlayerController* pLocalController, C_CSPlayerPawn* pLocalPawn)
+{
+        if (!C_GET(bool, Vars.bAntiAim))
+                return;
+
+        if (!I::Engine->IsConnected() || !I::Engine->IsInGame())
+                return;
+
+        if (!pLocalController || !pLocalController->IsPawnAlive())
+                return;
+
+        if (pCmd->nButtons.nValue & IN_USE || pCmd->nButtons.nValue & IN_ATTACK)
+                return;
+
+        int32_t nMoveType = pLocalPawn->GetMoveType();
+        if (nMoveType == MOVETYPE_NOCLIP || nMoveType == MOVETYPE_LADDER)
+                return;
+
+        float flPitch = 0.f;
+        float flYaw = 0.f;
+
+        switch (C_GET(int, Vars.iBaseYawType))
+        {
+        case 1:
+                flYaw -= 180.f;
+                break;
+        case 2:
+                flYaw += 180.f;
+                break;
+        default:
+                break;
+        }
+
+        switch (C_GET(int, Vars.iPitchType))
+        {
+        case 1:
+                flPitch = 120.f;
+                break;
+        case 2:
+                flPitch = -120.f;
+                break;
+        case 3:
+                flPitch = 0.f;
+                break;
+        default:
+                break;
+        }
+
+        pBaseCmd->pViewAngles->angValue.x = flPitch;
+        pBaseCmd->pViewAngles->angValue.y += flYaw;
+
+        pBaseCmd->pViewAngles->angValue.x = std::remainderf(pBaseCmd->pViewAngles->angValue.x, 360.f);
+        pBaseCmd->pViewAngles->angValue.y = std::remainderf(pBaseCmd->pViewAngles->angValue.y, 360.f);
+        pBaseCmd->pViewAngles->angValue.z = 0.f;
+}

--- a/cstrike/features/anti_aim/anti_aim.h
+++ b/cstrike/features/anti_aim/anti_aim.h
@@ -1,0 +1,14 @@
+#pragma once
+
+class CUserCmd;
+class CBaseUserCmdPB;
+class CCSPlayerController;
+class C_CSPlayerPawn;
+
+struct QAngle_t;
+
+namespace F::ANTIAIM
+{
+        inline QAngle_t angStoredViewBackup{};
+        void RunAA(CUserCmd* pCmd, CBaseUserCmdPB* pBaseCmd, CCSPlayerController* pLocalController, C_CSPlayerPawn* pLocalPawn);
+}


### PR DESCRIPTION
## Summary
- implement `anti_aim` feature
- expose anti-aim options in `Variables_t`
- hook anti-aim execution inside `OnCreateMove`
- add menu tab entries for anti-aim settings
- update project files to include new sources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cab5eee248324a6352a6c57c8794b